### PR TITLE
Fix nil pointer and add listen on address

### DIFF
--- a/backend/dns/arp.go
+++ b/backend/dns/arp.go
@@ -45,7 +45,7 @@ func ProcessARPTable() {
 }
 
 func updateARPTable() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "arp", "-a")

--- a/backend/dns/lists/blacklist.go
+++ b/backend/dns/lists/blacklist.go
@@ -51,8 +51,11 @@ func InitializeBlacklist(dbManager *database.DatabaseManager) (*Blacklist, error
 		return nil, fmt.Errorf("failed to initialize custom blocklist: %w", err)
 	}
 
-	_, _ = b.GetBlocklistUrls()
-	err := b.PopulateBlocklistCache()
+	_, err := b.GetBlocklistUrls()
+	if err != nil {
+		log.Error("Failed to fetch blocklist URLs: %v", err)
+	}
+	err = b.PopulateBlocklistCache()
 	if err != nil {
 		log.Error("Failed to initialize blocklist cache")
 	}
@@ -271,6 +274,7 @@ func (b *Blacklist) PopulateBlocklistCache() error {
 
 func (b *Blacklist) CountDomains() (int, error) {
 	var count int
+
 	err := b.DBManager.Conn.QueryRow(`SELECT COUNT(*) FROM blacklist`).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count domains: %w", err)

--- a/backend/dns/server/server.go
+++ b/backend/dns/server/server.go
@@ -77,7 +77,7 @@ type communicationMessage struct {
 func NewDNSServer(config *settings.Config, dbManager *database.DatabaseManager, notificationsManager *notification.Manager) (*DNSServer, error) {
 	blacklistEntry, err := lists.InitializeBlacklist(dbManager)
 	if err != nil {
-		log.Error("Failed to initialize blacklist")
+		return nil, fmt.Errorf("failed to initialize blacklist: %w", err)
 	}
 
 	whitelistEntry, err := lists.InitializeWhitelist(dbManager)
@@ -100,16 +100,19 @@ func NewDNSServer(config *settings.Config, dbManager *database.DatabaseManager, 
 	return server, nil
 }
 
-func (s *DNSServer) Init() (int, *dns.Server) {
+func (s *DNSServer) Init() (int, *dns.Server, error) {
 	server := &dns.Server{
-		Addr:      fmt.Sprintf(":%d", s.Config.DNS.Port),
+		Addr:      fmt.Sprintf("%s:%d", s.Config.DNS.Address, s.Config.DNS.Port),
 		Net:       "udp",
 		Handler:   s,
 		ReusePort: true,
 	}
 
-	domains, _ := s.Blacklist.CountDomains()
-	return domains, server
+	domains, err := s.Blacklist.CountDomains()
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to count blacklist domains: %w", err)
+	}
+	return domains, server, nil
 }
 
 func (s *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {

--- a/backend/settings/settings.go
+++ b/backend/settings/settings.go
@@ -20,6 +20,7 @@ type Status struct {
 
 type Config struct {
 	DNS struct {
+		Address           string   `yaml:"address" json:"address"`
 		Port              int      `yaml:"port" json:"port"`
 		CacheTTL          int      `yaml:"cacheTTL" json:"cacheTTL"`
 		PreferredUpstream string   `yaml:"preferredUpstream" json:"preferredUpstream"`
@@ -83,6 +84,7 @@ func createDefaultSettings(filePath string) (Config, error) {
 		LogLevel:            logging.INFO,
 	}
 
+	defaultConfig.DNS.Address = "0.0.0.0"
 	defaultConfig.DNS.Port = 53
 	defaultConfig.DNS.CacheTTL = 3600
 	defaultConfig.DNS.PreferredUpstream = "8.8.8.8:53"

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func startServer(config *settings.Config, ansi bool) {
 
 	dbManager, err := database.Initialize()
 	if err != nil {
-		log.Error("failed while initilizing database: %v", err)
+		log.Error("failed while initializing database: %v", err)
 		os.Exit(1)
 	}
 
@@ -137,7 +137,11 @@ func startServer(config *settings.Config, ansi bool) {
 
 	go dnsServer.ProcessLogEntries()
 
-	blockedDomains, serverInstance := dnsServer.Init()
+	blockedDomains, serverInstance, err := dnsServer.Init()
+	if err != nil {
+		log.Error("Failed to initialize DNS server: %s", err)
+		os.Exit(1)
+	}
 	currentVersion := setup.GetVersionOrDefault(version)
 
 	asciiart.AsciiArt(config, blockedDomains, currentVersion.Original(), config.API.Authentication, ansi)

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,4 +1,6 @@
 dns:
+  # Address for the DNS server to bind to. Default all IPv4 addresses.
+  address: 0.0.0.0
   # Port used for the DNS server. Standard DNS uses port 53.
   # This is the port where the server will listen for incoming DNS queries.
   port: 53


### PR DESCRIPTION
When you start Goaway as primary (and only) DNS it can not resolve the blacklist IP and crashes with a nil pointer error.
Also the code swallows an error on Init, so I changed it to return the error.
Besides that I added the option to specify the address (interface) to listen on. So that you can have for example an internal DNS an expose this as external DNS on a VPS with the local DNS as upstream.
Default address is: 0.0.0.0