### PR TITLE
Fix #23 unique resolution by domain instead of IP

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -49,6 +49,7 @@ type API struct {
 	router *gin.Engine
 	routes *gin.RouterGroup
 
+	DNSServer                *server.DNSServer
 	DBManager                *database.DatabaseManager
 	Blacklist                *lists.Blacklist
 	Whitelist                *lists.Whitelist
@@ -63,6 +64,7 @@ type API struct {
 func (api *API) Start(content embed.FS, dnsServer *server.DNSServer, errorChannel chan struct{}) {
 	api.initializeRouter()
 	api.configureCORS()
+	api.DNSServer = dnsServer
 	api.KeyManager = key.NewApiKeyManager(dnsServer.DBManager)
 	api.setupRoutes()
 

--- a/backend/api/resolution.go
+++ b/backend/api/resolution.go
@@ -33,7 +33,9 @@ func (api *API) createResolution(c *gin.Context) {
 	err := database.CreateNewResolution(api.DBManager.Conn, newResolution.IP, newResolution.Domain)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
+	api.DNSServer.RemoveCachedDomain(newResolution.Domain)
 	c.Status(http.StatusOK)
 }
 
@@ -64,5 +66,6 @@ func (api *API) deleteResolution(c *gin.Context) {
 		return
 	}
 
+	api.DNSServer.RemoveCachedDomain(domain)
 	c.JSON(http.StatusOK, gin.H{"deleted": rowsAffected})
 }

--- a/backend/dns/arp.go
+++ b/backend/dns/arp.go
@@ -45,7 +45,7 @@ func ProcessARPTable() {
 }
 
 func updateARPTable() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "arp", "-a")

--- a/backend/dns/database/database.go
+++ b/backend/dns/database/database.go
@@ -149,8 +149,8 @@ func NewRequestLogTable(db *sql.DB) error {
 
 func NewResolutionTable(db *sql.DB) error {
 	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS resolution (
-		ip TEXT,
-		domain TEXT NOT NULL PRIMARY KEY
+		domain TEXT NOT NULL PRIMARY KEY,
+		ip TEXT
 	)`)
 	if err != nil {
 		return err

--- a/backend/dns/database/database.go
+++ b/backend/dns/database/database.go
@@ -149,8 +149,8 @@ func NewRequestLogTable(db *sql.DB) error {
 
 func NewResolutionTable(db *sql.DB) error {
 	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS resolution (
-		ip TEXT PRIMARY KEY,
-		domain TEXT NOT NULL
+		ip TEXT,
+		domain TEXT NOT NULL PRIMARY KEY
 	)`)
 	if err != nil {
 		return err

--- a/backend/dns/database/resolution.go
+++ b/backend/dns/database/resolution.go
@@ -89,8 +89,8 @@ func CreateNewResolution(db *sql.DB, ip, domain string) error {
 
 	if _, err := stmt.Exec(ip, domain); err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") {
-			log.Error("IP already exists. Reason: %v", err)
-			return fmt.Errorf("ip already exists, must me unique")
+			log.Error("Domain already exists. Reason: %v", err)
+			return fmt.Errorf("domain already exists, must me unique")
 		}
 		log.Error("Could not save resolution. Reason: %v", err)
 		return fmt.Errorf("could not create new resolution")

--- a/backend/dns/lists/blacklist.go
+++ b/backend/dns/lists/blacklist.go
@@ -51,8 +51,11 @@ func InitializeBlacklist(dbManager *database.DatabaseManager) (*Blacklist, error
 		return nil, fmt.Errorf("failed to initialize custom blocklist: %w", err)
 	}
 
-	_, _ = b.GetBlocklistUrls()
-	err := b.PopulateBlocklistCache()
+	_, err := b.GetBlocklistUrls()
+	if err != nil {
+		log.Error("Failed to fetch blocklist URLs: %v", err)
+	}
+	err = b.PopulateBlocklistCache()
 	if err != nil {
 		log.Error("Failed to initialize blocklist cache")
 	}
@@ -271,6 +274,7 @@ func (b *Blacklist) PopulateBlocklistCache() error {
 
 func (b *Blacklist) CountDomains() (int, error) {
 	var count int
+
 	err := b.DBManager.Conn.QueryRow(`SELECT COUNT(*) FROM blacklist`).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count domains: %w", err)

--- a/backend/dns/server/cache.go
+++ b/backend/dns/server/cache.go
@@ -38,6 +38,23 @@ func (s *DNSServer) getCachedRecord(cached interface{}) ([]dns.RR, bool) {
 	return nil, false
 }
 
+func (s *DNSServer) RemoveCachedDomain(domain string) {
+	if domain == "" {
+		return
+	}
+
+	s.Cache.Range(func(key, value interface{}) bool {
+		cachedRecord, ok := value.(CachedRecord)
+		if !ok || cachedRecord.Domain != domain+"." {
+			return true
+		}
+
+		log.Debug("Removing cached record for domain %s", domain)
+		s.Cache.Delete(key)
+		return true
+	})
+}
+
 func (s *DNSServer) CacheRecord(cacheKey, domain string, ipAddresses []dns.RR, ttl uint32) {
 	if len(ipAddresses) == 0 {
 		return

--- a/backend/dns/server/server.go
+++ b/backend/dns/server/server.go
@@ -110,7 +110,7 @@ func (s *DNSServer) Init() (int, *dns.Server, error) {
 
 	domains, err := s.Blacklist.CountDomains()
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to count blacklist domains: %w", err)
+		return 0, nil, fmt.Errorf("failed to count blacklisted domains: %w", err)
 	}
 	return domains, server, nil
 }

--- a/backend/dns/server/server.go
+++ b/backend/dns/server/server.go
@@ -77,7 +77,7 @@ type communicationMessage struct {
 func NewDNSServer(config *settings.Config, dbManager *database.DatabaseManager, notificationsManager *notification.Manager) (*DNSServer, error) {
 	blacklistEntry, err := lists.InitializeBlacklist(dbManager)
 	if err != nil {
-		log.Error("Failed to initialize blacklist")
+		return nil, fmt.Errorf("failed to initialize blacklist: %w", err)
 	}
 
 	whitelistEntry, err := lists.InitializeWhitelist(dbManager)
@@ -100,16 +100,19 @@ func NewDNSServer(config *settings.Config, dbManager *database.DatabaseManager, 
 	return server, nil
 }
 
-func (s *DNSServer) Init() (int, *dns.Server) {
+func (s *DNSServer) Init() (int, *dns.Server, error) {
 	server := &dns.Server{
-		Addr:      fmt.Sprintf(":%d", s.Config.DNS.Port),
+		Addr:      fmt.Sprintf("%s:%d", s.Config.DNS.Address, s.Config.DNS.Port),
 		Net:       "udp",
 		Handler:   s,
 		ReusePort: true,
 	}
 
-	domains, _ := s.Blacklist.CountDomains()
-	return domains, server
+	domains, err := s.Blacklist.CountDomains()
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to count blacklist domains: %w", err)
+	}
+	return domains, server, nil
 }
 
 func (s *DNSServer) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {

--- a/backend/settings/settings.go
+++ b/backend/settings/settings.go
@@ -20,6 +20,7 @@ type Status struct {
 
 type Config struct {
 	DNS struct {
+		Address           string   `yaml:"address" json:"address"`
 		Port              int      `yaml:"port" json:"port"`
 		CacheTTL          int      `yaml:"cacheTTL" json:"cacheTTL"`
 		PreferredUpstream string   `yaml:"preferredUpstream" json:"preferredUpstream"`
@@ -83,6 +84,7 @@ func createDefaultSettings(filePath string) (Config, error) {
 		LogLevel:            logging.INFO,
 	}
 
+	defaultConfig.DNS.Address = "0.0.0.0"
 	defaultConfig.DNS.Port = 53
 	defaultConfig.DNS.CacheTTL = 3600
 	defaultConfig.DNS.PreferredUpstream = "8.8.8.8:53"

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func startServer(config *settings.Config, ansi bool) {
 
 	dbManager, err := database.Initialize()
 	if err != nil {
-		log.Error("failed while initilizing database: %v", err)
+		log.Error("failed while initializing database: %v", err)
 		os.Exit(1)
 	}
 
@@ -137,7 +137,11 @@ func startServer(config *settings.Config, ansi bool) {
 
 	go dnsServer.ProcessLogEntries()
 
-	blockedDomains, serverInstance := dnsServer.Init()
+	blockedDomains, serverInstance, err := dnsServer.Init()
+	if err != nil {
+		log.Error("Failed to initialize DNS server: %s", err)
+		os.Exit(1)
+	}
 	currentVersion := setup.GetVersionOrDefault(version)
 
 	asciiart.AsciiArt(config, blockedDomains, currentVersion.Original(), config.API.Authentication, ansi)


### PR DESCRIPTION
This PR contains a fix for issue #23 making the domain unique instead of the IP address.
**Breaking change: make domain unique in custom resolution not IP**

Also removing domain from cache when adding or removing a custom resolution so it works directly

```
-- 1. Rename the old table
ALTER TABLE resolution RENAME TO resolution_old;

-- 2. Create the new table with domain as primary key
CREATE TABLE resolution (
	domain TEXT PRIMARY KEY,
	ip TEXT NOT NULL
);

```
⚠️ Important: Before step 3, you should check for duplicate domain values:
```
SELECT domain, COUNT(*) as cnt FROM resolution_old GROUP BY domain HAVING cnt > 1;
```

```
-- 3. Copy data (ensure no duplicate domains!)
INSERT INTO resolution (domain, ip)
SELECT domain, ip FROM resolution_old;

-- 4. Drop the old table
DROP TABLE resolution_old;
```
