### PR TITLE
Add Phishing Army blocklists to recommended sources

### DIFF
--- a/client/src/app/lists/addList.tsx
+++ b/client/src/app/lists/addList.tsx
@@ -108,6 +108,23 @@ const RECOMMENDED_SOURCES = [
         description: "Ultimate domain list"
       }
     ]
+  },
+  {
+    name: "Phishing Army",
+    website: "https://phishing.army",
+    description: "Blocklist to filter Phishing domain",
+    lists: [
+      {
+        name: "Phishing Army",
+        url: "https://phishing.army/download/phishing_army_blocklist.txt",
+        description: "Blocklist of phishing domains"
+      },
+      {
+        name: "Phishing Army - Extended",
+        url: "https://phishing.army/download/phishing_army_blocklist_extended.txt",
+        description: "Extended blocklist of phishing domains"
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
This PR adds Phishing Army (standard and extended) to the list of recommended blocklist sources in the AddList dialog.

Phishing Army is a widely used, community-maintained phishing blocklist project.

It protects against phishing domains and is actively maintained, with more than 500,000 monthly users relying on it.

Two variants are included:
- Phishing Army (Standard)
- Phishing Army (Extended)

This enhancement provides users with an additional trusted source to improve protection against phishing attacks.