### PR TITLE
fix: switch go module for db import

### DIFF
--- a/backend/api/settings.go
+++ b/backend/api/settings.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/driver/sqlite"
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
 


### PR DESCRIPTION
The API still used the SQLite Driver from `gorm` which results in error on Servers where a C Compiler isn't installed:

```
[goaway]   | 2025/10/04 18:08:55 [ERROR] Failed to open imported database with GORM: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
```

Switching to `glebarez/sqlite` solves the problem since it's a fully go written driver.
(Same driver that is used in the rest of the code [backend/dns/database/database.go#L9](backend/dns/database/database.go#L9))