### PR TITLE
fix: dynamically generate secret in settings.yaml

### DIFF
--- a/backend/api/auth.go
+++ b/backend/api/auth.go
@@ -45,7 +45,7 @@ func (api *API) handleLogin(c *gin.Context) {
 	}
 
 	if api.UserService.Authenticate(loginUser.Username, loginUser.Password) {
-		token, err := generateToken(loginUser.Username)
+		token, err := generateToken(loginUser.Username, api.Config.API.JWTSecret)
 		if err != nil {
 			log.Info("Token generation failed for user %s: %v", loginUser.Username, err)
 			c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/settings/model.go
+++ b/backend/settings/model.go
@@ -45,6 +45,7 @@ type RateLimitConfig struct {
 type APIConfig struct {
 	Port           int             `yaml:"port" json:"port"`
 	Authentication bool            `yaml:"authentication" json:"authentication"`
+	JWTSecret      string          `yaml:"jwtSecret" json:"-"`
 	RateLimit      RateLimitConfig `yaml:"rateLimit" json:"rateLimit"`
 }
 

--- a/backend/settings/settings.go
+++ b/backend/settings/settings.go
@@ -1,7 +1,9 @@
 package settings
 
 import (
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"goaway/backend/logging"
 	"net"
@@ -83,6 +85,16 @@ func (config *Config) Update(updatedSettings Config) {
 	config.Save()
 }
 
+func GenerateSecret() string {
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	if err != nil {
+		log.Error("Failed to generate secret: %v", err)
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(secret)
+}
+
 func createDefaultSettings(filePath string) (Config, error) {
 	defaultConfig := Config{
 		DNS: DNSConfig{
@@ -110,6 +122,7 @@ func createDefaultSettings(filePath string) (Config, error) {
 		API: APIConfig{
 			Port:           getEnvAsIntWithDefault("WEBSITE_PORT", 8080),
 			Authentication: true,
+			JWTSecret:      GenerateSecret(),
 			RateLimit: RateLimitConfig{
 				Enabled:  true,
 				MaxTries: 5,

--- a/backend/setup/setup.go
+++ b/backend/setup/setup.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strconv"
@@ -133,6 +134,12 @@ func InitializeSettings(flags *SetFlags) *settings.Config {
 	}
 
 	UpdateConfig(&config, flags)
+
+	secret, err := base64.RawURLEncoding.DecodeString(config.API.JWTSecret)
+	if err != nil || len(secret) == 0 {
+		config.API.JWTSecret = settings.GenerateSecret()
+	}
+
 	config.Save()
 
 	return &config

--- a/settings.yaml
+++ b/settings.yaml
@@ -52,6 +52,10 @@ api:
   # Set to true for increased security.
   authentication: true
 
+  # Secret key used for signing JWT tokens.
+  # If empty, a random key will be generated automatically.
+  jwtSecret: ""
+
   # Currently only protects the login route
   rateLimit:
     # Enable or disable the usage of rate limiting


### PR DESCRIPTION
* resolves #90 
* dynamically generates secret on startup
* persist secret in settings.yaml
* extends APIConfig with JWTSecret
* generateToken and parseToken accept a base64 encoded secret argument