### PR TITLE
fix(dns): return upstream Rcode instead of hardcoding SERVFAIL when no answers

### DIFF
--- a/backend/dns/server/handler.go
+++ b/backend/dns/server/handler.go
@@ -228,7 +228,11 @@ func (s *DNSServer) reverseDNSLookup(clientIP string) string {
 			d := net.Dialer{
 				Timeout: 2 * time.Second,
 			}
-			return d.DialContext(ctx, "udp", s.Config.DNS.Gateway)
+			gateway := s.Config.DNS.Gateway
+			if _, _, err := net.SplitHostPort(gateway); err != nil {
+				gateway = net.JoinHostPort(gateway, "53")
+			}
+			return d.DialContext(ctx, "udp", gateway)
 		},
 	}
 

--- a/backend/dns/server/handler.go
+++ b/backend/dns/server/handler.go
@@ -495,7 +495,9 @@ func (s *DNSServer) handleStandardQuery(request *Request) model.RequestLogEntry 
 	if request.Msg.RecursionDesired {
 		request.Msg.RecursionAvailable = true
 	}
-	if len(answers) == 0 {
+	if rcode, ok := dns.StringToRcode[status]; ok {
+		request.Msg.Rcode = rcode
+	} else {
 		request.Msg.Rcode = dns.RcodeServerFailure
 	}
 


### PR DESCRIPTION
## Problem

When a client queries for a hostname that only has an A record (no AAAA), the upstream resolver correctly returns `NOERROR` with an empty answer section for the AAAA query. However, `handleStandardQuery` was overriding this with `RcodeServerFailure` whenever `len(answers) == 0`, causing clients to receive a spurious `SERVFAIL` alongside the valid A record response.

This commonly affects internal/local hostnames that only have A records, where the client receives both the correct IP and a SERVFAIL — making tools like `nslookup` report failure despite resolving correctly.

## Root Cause

In `handleStandardQuery`:

```go
// Before: hardcodes SERVFAIL whenever there are no answers
if len(answers) == 0 {
    request.Msg.Rcode = dns.RcodeServerFailure
}
```

The `status` string returned from `Resolve()` (which reflects the actual upstream Rcode) was only used for logging, never applied to the response message.

## Fix

Use the upstream status to set the Rcode, matching the existing pattern already used in `forwardPTRQueryUpstream`:

```go
if rcode, ok := dns.StringToRcode[status]; ok {
    request.Msg.Rcode = rcode
} else {
    request.Msg.Rcode = dns.RcodeServerFailure
}
```

## Test

Before fix:
```
$ nslookup ha.iot.home 192.168.253.20
Non-authoritative answer:
Name:   ha.iot.home
Address: 192.168.254.50
;; Got SERVFAIL reply from 192.168.253.20
** server can't find ha.iot.home: SERVFAIL
```

After fix:
```
$ nslookup ha.iot.home 192.168.253.20
Non-authoritative answer:
Name:   ha.iot.home
Address: 192.168.254.50
```