### PR TITLE
fix: respect query type for local DNS resolutions

### DIFF
--- a/backend/dns/server/handler.go
+++ b/backend/dns/server/handler.go
@@ -763,7 +763,7 @@ func (s *DNSServer) QueryUpstream(req *Request) ([]dns.RR, uint32, string) {
 		go s.WSCom(communicationMessage{IP: "", Client: false, Upstream: true, DNS: false})
 
 		q := req.Question.Header()
-		upstreamMsg := dns.NewMsg(q.Name, q.Class)
+		upstreamMsg := dns.NewMsg(q.Name, dns.RRToType(req.Question))
 		upstreamMsg.RecursionDesired = true
 		upstreamMsg.ID = dns.ID()
 

--- a/backend/dns/server/handler.go
+++ b/backend/dns/server/handler.go
@@ -670,15 +670,17 @@ func (s *DNSServer) handleStandardQuery(request *Request) model.RequestLogEntry 
 }
 
 func (s *DNSServer) Resolve(req *Request) ([]dns.RR, bool, string) {
-	cacheKey := req.Question.Header().Name + ":" + strconv.Itoa(int(req.Question.Header().Class))
+	cacheKey := req.Question.Header().Name + ":" + strconv.Itoa(int(dns.RRToType(req.Question)))
 	if cached, found := s.DomainCache.Load(cacheKey); found {
 		if ipAddresses, valid := s.getCachedRecord(cached); valid {
 			return ipAddresses, true, dnsutil.CodeToString(dns.RcodeSuccess)
 		}
 	}
 
-	if answers, ttl, status := s.resolveResolution(req.Question.Header().Name); len(answers) > 0 {
-		s.CacheRecord(cacheKey, req.Question.Header().Name, answers, ttl)
+	if answers, ttl, status, matched := s.resolveResolution(req); matched {
+		if len(answers) > 0 {
+			s.CacheRecord(cacheKey, req.Question.Header().Name, answers, ttl)
+		}
 		return answers, false, status
 	}
 
@@ -689,49 +691,45 @@ func (s *DNSServer) Resolve(req *Request) ([]dns.RR, bool, string) {
 	return answers, false, status
 }
 
-func (s *DNSServer) resolveResolution(domain string) ([]dns.RR, uint32, string) {
+func (s *DNSServer) resolveResolution(req *Request) ([]dns.RR, uint32, string, bool) {
 	var (
 		records []dns.RR
-		rr      dns.RR
 		ttl     = uint32(s.Config.DNS.CacheTTL)
 		status  = dnsutil.CodeToString(dns.RcodeSuccess)
+		domain  = req.Question.Header().Name
 	)
 
 	ipFound, err := s.ResolutionService.GetResolution(domain)
 	if err != nil {
 		log.Error("Database lookup error for domain (%s): %v", domain, err)
-		return nil, 0, dnsutil.CodeToString(dns.RcodeServerFailure)
+		return nil, 0, dnsutil.CodeToString(dns.RcodeServerFailure), true
 	}
 
 	if ipFound == "" {
-		status = dnsutil.CodeToString(dns.RcodeNameError)
-	} else {
-		ip, err := netip.ParseAddr(ipFound)
-		if err != nil {
-			log.Warning("Failed to parse IP from database for domain '%s': %v", domain, err)
-			return nil, 0, dnsutil.CodeToString(dns.RcodeServerFailure)
-		}
-		if ip.Is4() {
-			rr = &dns.A{
-				Hdr: dns.Header{
-					Name:  dnsutil.Fqdn(domain),
-					TTL:   ttl,
-					Class: dns.ClassINET,
-				},
-				A: rdata.A{Addr: ip}}
-		} else {
-			rr = &dns.AAAA{
-				Hdr: dns.Header{
-					Name:  dnsutil.Fqdn(domain),
-					TTL:   ttl,
-					Class: dns.ClassINET,
-				},
-				AAAA: rdata.AAAA{Addr: ip},
-			}
-		}
-		records = append(records, rr)
+		return nil, 0, dnsutil.CodeToString(dns.RcodeNameError), false
 	}
-	return records, ttl, status
+
+	ip, err := netip.ParseAddr(ipFound)
+	if err != nil {
+		log.Warning("Failed to parse IP from database for domain '%s': %v", domain, err)
+		return nil, 0, dnsutil.CodeToString(dns.RcodeServerFailure), true
+	}
+
+	qType := dns.RRToType(req.Question)
+	if ip.Is4() {
+		if qType == dns.TypeA || qType == dns.TypeANY {
+			records = append(records, &dns.A{
+				Hdr: dns.Header{Name: dnsutil.Fqdn(domain), TTL: ttl, Class: dns.ClassINET},
+				A:   rdata.A{Addr: ip},
+			})
+		}
+	} else if qType == dns.TypeAAAA || qType == dns.TypeANY {
+		records = append(records, &dns.AAAA{
+			Hdr:  dns.Header{Name: dnsutil.Fqdn(domain), TTL: ttl, Class: dns.ClassINET},
+			AAAA: rdata.AAAA{Addr: ip},
+		})
+	}
+	return records, ttl, status, true
 }
 
 func (s *DNSServer) resolveCNAMEChain(req *Request, visited map[string]bool) ([]dns.RR, uint32, string) {

--- a/test/resolution/resolution_test.go
+++ b/test/resolution/resolution_test.go
@@ -1,10 +1,16 @@
 package resolution
 
 import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/netip"
 	"testing"
 
 	"codeberg.org/miekg/dns"
 	"codeberg.org/miekg/dns/dnsutil"
+	"codeberg.org/miekg/dns/rdata"
 	"github.com/stretchr/testify/require"
 
 	"goaway/backend/dns/server"
@@ -51,4 +57,45 @@ func TestResolveLocalEntryRespectsQueryType(t *testing.T) {
 	answers, _, status = s.Resolve(aaaaReq)
 	require.Equal(t, dnsutil.CodeToString(dns.RcodeSuccess), status)
 	require.Empty(t, answers)
+}
+
+func TestUpstreamQueryUsesRequestedType(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	gotType := make(chan uint16, 1)
+	ready := make(chan struct{})
+	srv := &dns.Server{
+		PacketConn:        pc,
+		NotifyStartedFunc: func(context.Context) { close(ready) },
+		Handler: dns.HandlerFunc(func(_ context.Context, w dns.ResponseWriter, r *dns.Msg) {
+			gotType <- dns.RRToType(r.Question[0])
+			resp := new(dns.Msg)
+			dnsutil.SetReply(resp, r)
+			resp.Answer = []dns.RR{&dns.AAAA{
+				Hdr:  dns.Header{Name: r.Question[0].Header().Name, TTL: 60, Class: dns.ClassINET},
+				AAAA: rdata.AAAA{Addr: netip.MustParseAddr("2001:db8::1")},
+			}}
+			_, _ = io.Copy(w, resp)
+		}),
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	defer srv.Shutdown(context.Background())
+	<-ready
+
+	cfg := &settings.Config{}
+	cfg.DNS.CacheTTL = 60
+	cfg.DNS.Upstream.Preferred = pc.LocalAddr().String()
+	s, err := server.NewDNSServer(cfg, nil, tls.Certificate{})
+	require.NoError(t, err)
+	s.ResolutionService = resolution.NewService(&fakeRepo{entries: map[string]string{}})
+
+	req := newRequest("example.com.", &dns.AAAA{Hdr: dns.Header{Name: "example.com."}})
+	answers, _, _ := s.Resolve(req)
+
+	require.Equal(t, dns.TypeAAAA, <-gotType)
+	require.Len(t, answers, 1)
+	_, ok := answers[0].(*dns.AAAA)
+	require.True(t, ok)
 }

--- a/test/resolution/resolution_test.go
+++ b/test/resolution/resolution_test.go
@@ -1,0 +1,54 @@
+package resolution
+
+import (
+	"testing"
+
+	"codeberg.org/miekg/dns"
+	"codeberg.org/miekg/dns/dnsutil"
+	"github.com/stretchr/testify/require"
+
+	"goaway/backend/dns/server"
+	"goaway/backend/resolution"
+	"goaway/backend/settings"
+)
+
+type fakeRepo struct {
+	entries map[string]string
+}
+
+func (r *fakeRepo) CreateResolution(ip, domain string) error        { return nil }
+func (r *fakeRepo) FindResolution(domain string) (string, error)    { return r.entries[domain], nil }
+func (r *fakeRepo) FindResolutions() (map[string]string, error)     { return r.entries, nil }
+func (r *fakeRepo) DeleteResolution(ip, domain string) (int, error) { return 0, nil }
+
+func newServer(entries map[string]string) *server.DNSServer {
+	cfg := &settings.Config{}
+	cfg.DNS.CacheTTL = 60
+	return &server.DNSServer{
+		Config:            cfg,
+		ResolutionService: resolution.NewService(&fakeRepo{entries: entries}),
+	}
+}
+
+func newRequest(name string, qtype dns.RR) *server.Request {
+	return &server.Request{
+		Msg:      new(dns.Msg),
+		Question: qtype,
+	}
+}
+
+func TestResolveLocalEntryRespectsQueryType(t *testing.T) {
+	s := newServer(map[string]string{"test.local.": "10.0.10.3"})
+
+	aReq := newRequest("test.local.", &dns.A{Hdr: dns.Header{Name: "test.local."}})
+	answers, _, status := s.Resolve(aReq)
+	require.Equal(t, dnsutil.CodeToString(dns.RcodeSuccess), status)
+	require.Len(t, answers, 1)
+	_, ok := answers[0].(*dns.A)
+	require.True(t, ok)
+
+	aaaaReq := newRequest("test.local.", &dns.AAAA{Hdr: dns.Header{Name: "test.local."}})
+	answers, _, status = s.Resolve(aaaaReq)
+	require.Equal(t, dnsutil.CodeToString(dns.RcodeSuccess), status)
+	require.Empty(t, answers)
+}


### PR DESCRIPTION
A configured local resolution maps a domain to a single IP, but `resolveResolution` built an A or AAAA record purely from the stored address family and returned it for any query type, and the response cache keyed entries by class instead of query type. So `dig name AAAA` returned the IPv4 A record, which strict resolvers like nginx reject. This returns the matching record type only (NODATA otherwise) and includes the query type in the cache key. Closes #128